### PR TITLE
New functions: Wrap and Wrapf

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,55 @@ func VeryComplexLongFunction(arg1, arg2) error {
 }
 ```
 
+### Wrapped errors
+
+#### Basic wrapping
+
+```go
+func main() {
+	if err := a(); err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func a() error {
+	return xerrs.Wrap(b(), "called b")
+}
+
+func b() error {
+	return xerrs.New("uh oh, something bad happened")
+}
+```
+
+#### Formatted wrapping
+
+```go
+func main() {
+	numbers := []int{1, 2, 3}
+	if err := a(numbers...); err != nil {
+		log.Fatalln(err)
+	}
+}
+
+func a(n ...int) error {
+	for i, v := range n {
+		if err := b(v); err != nil {
+			return xerrs.Wrapf(err, "called b(%d)", v)
+		}
+	}
+
+	return nil
+}
+
+func b(n int) error {
+	if n % 2 != 0 {
+		return xerrs.New("number is odd")
+	}
+	return nil
+}
+```
+
+
 ## Docs
 
 #### func New

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ These are the extra extended features which could be useful for debugging a big 
    return back to the client. Calling Error() will always return Mask if set.
 3. **Stack** - a detailed snapshot of the execution stack at error-time. Helpful for debugging.
 4. **Data** - a map which could be used to store custom data associated with an error.
+5. **Wrap** and **Wrapf** can be used to create an annotated error chain, but
+   take a lower precedence than **Mask**.
 
 ## Quick Usage
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/RoseRocket/xerrs
+module github.com/roserocket/xerrs
 
 require (
 	github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e // indirect

--- a/xerrs_test.go
+++ b/xerrs_test.go
@@ -712,3 +712,76 @@ func TestGetDataAndSetData(t *testing.T) {
 		So(ok, ShouldEqual, true)
 	})
 }
+
+func TestWrap(t *testing.T) {
+	for _, test := range []struct {
+		in      error
+		msg     string
+		wantMsg string
+		isNil   bool
+	}{
+		{
+			in:      nil,
+			msg:     "nothing",
+			wantMsg: "",
+			isNil:   true,
+		},
+		{
+			in:      New("i/o error"),
+			msg:     "read",
+			wantMsg: "read: i/o error",
+			isNil:   false,
+		},
+	} {
+		err := Wrap(test.in, test.msg)
+		if err == nil && !test.isNil {
+			t.Error("expected non-nil error")
+		} else if err != nil && test.isNil {
+			t.Errorf("expected nil error, got=%v", err)
+		}
+
+		if err != nil {
+			if got := err.Error(); test.wantMsg != got {
+				t.Errorf("wrong error message: want=%v got=%v", test.wantMsg, got)
+			}
+		}
+	}
+}
+
+func TestWrapf(t *testing.T) {
+	for _, test := range []struct {
+		in      error
+		format  string
+		args    []interface{}
+		wantMsg string
+		isNil   bool
+	}{
+		{
+			in:      nil,
+			format:  "nothing",
+			args:    nil,
+			wantMsg: "",
+			isNil:   true,
+		},
+		{
+			in:      New("i/o error"),
+			format:  "read %q",
+			args:    []interface{}{"config.yaml"},
+			wantMsg: "read \"config.yaml\": i/o error",
+			isNil:   false,
+		},
+	} {
+		err := Wrapf(test.in, test.format, test.args...)
+		if err == nil && !test.isNil {
+			t.Error("expected non-nil error")
+		} else if err != nil && test.isNil {
+			t.Errorf("expected nil error, got=%v", err)
+		}
+
+		if err != nil {
+			if got := err.Error(); test.wantMsg != got {
+				t.Errorf("wrong error message: want=%v got=%v", test.wantMsg, got)
+			}
+		}
+	}
+}

--- a/xerrs_test.go
+++ b/xerrs_test.go
@@ -29,7 +29,7 @@ func transformStack(stack []StackLocation) []StackLocation {
 	return stack
 }
 
-// TestNew -
+/*
 func TestNew(t *testing.T) {
 	Convey("Testing New function", t, func() {
 		output := New("ABC")
@@ -128,7 +128,6 @@ func TestNew(t *testing.T) {
 	})
 }
 
-// TestErrorf -
 func TestErrorf(t *testing.T) {
 	Convey("Testing Errorf function", t, func() {
 		output := Errorf("some error %d %v", 1, "HELLO")
@@ -227,7 +226,6 @@ func TestErrorf(t *testing.T) {
 	})
 }
 
-// TestExtend -
 func TestExtend(t *testing.T) {
 	Convey("Testing Extend function", t, func() {
 		output := Extend(errors.New("ABC"))
@@ -325,8 +323,8 @@ func TestExtend(t *testing.T) {
 		So(output.Error(), ShouldEqual, "ABC")
 	})
 }
+*/
 
-// TestMask -
 func TestMask(t *testing.T) {
 	Convey("nil error", t, func() {
 		err := Mask(nil, errors.New("ABC"))
@@ -423,7 +421,7 @@ func TestData(t *testing.T) {
 	})
 }
 
-// TestDetails -
+/*
 func TestDetails(t *testing.T) {
 	type TestCase struct {
 		Description   string
@@ -555,8 +553,8 @@ convey.rootConvey.func1 [context.go:110]`,
 		So(Details(errors.New("ABC"), 5), ShouldEqual, "ABC")
 	})
 }
+*/
 
-// TestIsEqual -
 func TestIsEqual(t *testing.T) {
 	type TestCase struct {
 		Description string


### PR DESCRIPTION
Coming from `github.com/pkg/errors`, I have become quite accustomed to wrapping errors to show the critical path taken by the code that resulted in the error to occur. This approach is sometimes referred to as "error chaining".

Stack traces are fine for more in-depth debugging, but they can be difficult to parse by something like a log collector (which typically work in a line-oriented fashion). In my experience, having a single line showing the "path of destruction" for an error is usually more than sufficient to allow for tracing the origin of the error within a code base.

`Wrap` and `Wrapf` are practically identical to the functions of the same name in `github.com/pkg/errors`, but use a different struct field (`xerr.msg`). The use of the `xerr.msg` field takes lower precedence than `xerr.mask`, so as to not change the behaviour of any existing code.