### PR TITLE
[APPS] - Fix package declaration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,1 @@
-module github.com/roserocket/xerrs
+module github.com/RoseRocket/xerrs


### PR DESCRIPTION
Was getting this when trying to import into `micro` repo:
```
	github.com/RoseRocket/xerrs: github.com/RoseRocket/xerrs@v1.1.0: parsing go.mod:
	module declares its path as: github.com/roserocket/xerrs
	        but was required as: github.com/RoseRocket/xerrs
```